### PR TITLE
Unparsing data string was stripping 0 from the end of a hex value

### DIFF
--- a/src/serialTool.pyw
+++ b/src/serialTool.pyw
@@ -1019,8 +1019,7 @@ class Gui(QtWidgets.QMainWindow):
 
                     # handle HEX numbers (can be one or more bytes)
                     if dataPart.lower().startswith('0x'):
-                        dataPart = dataPart.lower()
-                        dataPart = dataPart.lstrip('0x')
+                        dataPart = dataPart.lower()[2:]
                         if len(dataPart) % 2:
                             dataPart = '0' + dataPart
                         hexNumbers = list(bytearray.fromhex(dataPart))

--- a/src/serialTool.pyw
+++ b/src/serialTool.pyw
@@ -1020,7 +1020,7 @@ class Gui(QtWidgets.QMainWindow):
                     # handle HEX numbers (can be one or more bytes)
                     if dataPart.lower().startswith('0x'):
                         dataPart = dataPart.lower()
-                        dataPart = dataPart.strip('0x')
+                        dataPart = dataPart.lstrip('0x')
                         if len(dataPart) % 2:
                             dataPart = '0' + dataPart
                         hexNumbers = list(bytearray.fromhex(dataPart))


### PR DESCRIPTION
Ex: 0x50 would send 0x05. Changed to lstrip
![Screenshot 2021-02-15 161802](https://user-images.githubusercontent.com/38441083/107997832-6a639780-6fa9-11eb-9362-070db70d92b4.png)
